### PR TITLE
Add circleci ubuntu gcloudsdk image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2
+jobs:
+  build_push:
+    docker:
+    - image: cimg/base:stable-20.04
+    steps:
+    - checkout
+    - setup_remote_docker
+    - run:
+        name: Login to Docker hub
+        command: docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+    - run:
+        name: Build image
+        command: make build
+    - run:
+        name: Push image
+        command: make push
+
+workflows:
+  version: 2
+  build_push:
+    jobs:
+    - build_push:
+        filters:
+          branches:
+            only:
+            - master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM cimg/base:stable-20.04
+
+ARG GOOGLE_SDK_VERSION=323.0.0-0
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    sudo apt-get install -y apt-transport-https ca-certificates gnupg && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    sudo apt-get update && sudo apt-get install -y google-cloud-sdk=$GOOGLE_SDK_VERSION
+
+ARG SKAFFOLD_VERSION=v1.17.2
+RUN sudo curl -Lo skaffold https://github.com/GoogleContainerTools/skaffold/releases/download/$SKAFFOLD_VERSION/skaffold-linux-amd64 && \
+    sudo chmod +x skaffold && sudo mv skaffold /usr/local/bin
+
+ARG HELM_VERSION=v3.4.2
+RUN sudo curl -Lo helm.tar.gz https://get.helm.sh/helm-$HELM_VERSION-linux-amd64.tar.gz && \
+    sudo tar zxvf helm.tar.gz && sudo mv linux-amd64/helm /usr/local/bin && \
+    sudo rm helm.tar.gz && sudo rm -rf linux-amd64
+
+RUN sudo apt-get install -y kubectl jq

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+REPO=fyndiq
+NAME=circleci-ubuntu-gcloudsdk
+TAG=ubuntu-stable-20.04-gcloudsdk321.0.0-v1
+
+build:
+	docker build -t $(REPO)/$(NAME):$(TAG) .
+	docker tag $(REPO)/$(NAME):$(TAG) $(REPO)/$(NAME):latest
+
+run:
+	docker run -it --rm $(REPO)/$(NAME):$(TAG)
+
+push:
+	docker push $(REPO)/$(NAME):$(TAG)
+	docker push $(REPO)/$(NAME):latest

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# CircleCI Ubuntu Google Cloud SDK
+Docker image that extends the `cimg/base` image with Google's Cloud SDK.
+
+See [Dockerhub](https://hub.docker.com/r/fyndiq/circleci-ubuntu-gcloudsdk/) for
+available tags


### PR DESCRIPTION
**Background**
Add Ubuntu base image to be used in service pipelines. If we just run docker to build and test our applications we don't need specialised language images.